### PR TITLE
Let me extend the rule

### DIFF
--- a/src/Rules/DisposableEmailRule.php
+++ b/src/Rules/DisposableEmailRule.php
@@ -9,7 +9,7 @@ use EragLaravelDisposableEmail\Services\EmailServices;
 use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Translation\PotentiallyTranslatedString;
 
-final class DisposableEmailRule implements ValidationRule
+class DisposableEmailRule implements ValidationRule
 {
     /**
      * List of unauthorized email providers.


### PR DESCRIPTION
I propose to remove the final modifier from the PHP class to allow it to be extended.

There is no reason to mark the class as final. Allowing inheritance provides more flexibility for extending the base functionality if needed. This change does not affect the current behavior of the class.