### PR TITLE
[CHORE] Add tests

### DIFF
--- a/.github/workflows/run_tests.yml
+++ b/.github/workflows/run_tests.yml
@@ -1,0 +1,66 @@
+name: Run Tests
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  test:
+    runs-on: ${{ matrix.os }}
+    
+    strategy:
+      fail-fast: false
+      
+      matrix:
+        os: [ubuntu-latest]
+        php: [8.5, 8.4, 8.3, 8.2, 8.1]
+        laravel: ['13.*', '12.*', '11.*']
+        dependency-version: [prefer-stable]
+        
+        include:
+          - laravel: 11.*
+            testbench: 9.*
+          - laravel: 12.*
+            testbench: 10.*
+          - laravel: 13.*
+            testbench: 11.*
+        exclude:
+          # Laravel 11 requires PHP 8.2+
+           - laravel: 11.*
+             php: 8.1
+          # Laravel 12 requires PHP 8.2+
+           - laravel: 12.*
+             php: 8.1
+          # Laravel 13 requires PHP 8.3+
+           - laravel: 13.*
+             php: 8.1
+           - laravel: 13.*
+             php: 8.2
+
+    name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.dependency-version }} - ${{ matrix.os }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: dom, curl, libxml, mbstring, zip, pcntl, pdo, sqlite, pdo_sqlite, bcmath, soap, intl, gd, exif, iconv, imagick
+          coverage: none
+
+      - name: Setup Composer Cache
+        uses: actions/cache@v5
+        with:
+          path: ~/.composer/cache
+          key: ${{ matrix.os }}-php-${{ matrix.php }}-composer-${{ hashFiles('**/composer.json') }}
+          restore-keys: ${{ matrix.os }}-php-${{ matrix.php }}-composer-
+
+      - name: Install dependencies
+        run: |
+          composer require "laravel/framework:${{ matrix.laravel }}" "orchestra/testbench:${{ matrix.testbench }}" --no-interaction --no-update
+          composer update --${{ matrix.dependency-version }} --prefer-dist --no-interaction
+
+      - name: Run Pest tests
+        run: composer test:unit

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,6 @@
     ],
     "require": {
         "php": ">=8.1.0",
-        "laravel/pint": "^1.13",
         "illuminate/support": "^10.0|^11.0|^12.0|^13.0",
         "illuminate/console": "^10.0|^11.0|^12.0|^13.0",
         "illuminate/validation": "^10.0|^11.0|^12.0|^13.0",
@@ -37,10 +36,27 @@
         "illuminate/filesystem": "^10.0|^11.0|^12.0|^13.0",
         "guzzlehttp/guzzle": "^7.0"
     },
+    "require-dev": {
+        "laravel/pint": "^1.13",
+        "orchestra/testbench": "^8.36|^9.15|^10.8|^11.0",
+        "pestphp/pest": "^1.22|^2.0|^3.0|^4.0",
+        "pestphp/pest-plugin-laravel": "^1.3|^2.0|^3.0|^4.0"
+  },
     "autoload": {
         "psr-4": {
             "EragLaravelDisposableEmail\\": "src/"
         }
+    },
+    "autoload-dev": {
+        "psr-4": {
+            "Tests\\": "tests/"
+        }
+    },
+    "scripts": {
+        "lint": "pint --parallel",
+        "test:lint": "pint --parallel --test",
+        "test:unit": "pest --order-by=random",
+        "test": ["@test:lint", "@test:unit"]
     },
     "prefer-stable": true,
     "extra": {
@@ -51,6 +67,11 @@
             "aliases": {
                 "Disposable": "EragLaravelDisposableEmail\\Facades\\Disposable"
             }
+        }
+    },
+    "config": {
+        "allow-plugins": {
+            "pestphp/pest-plugin": true
         }
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
+         bootstrap="vendor/autoload.php"
+         colors="true"
+>
+    <testsuites>
+        <testsuite name="Unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
+        <testsuite name="Feature">
+            <directory>tests/Feature</directory>
+        </testsuite>
+    </testsuites>
+    <source>
+        <include>
+            <directory>app</directory>
+        </include>
+    </source>
+    <php>
+        <env name="APP_ENV" value="testing"/>
+        <env name="APP_MAINTENANCE_DRIVER" value="file"/>
+        <env name="BCRYPT_ROUNDS" value="4"/>
+        <env name="CACHE_STORE" value="array"/>
+        <env name="DB_CONNECTION" value="sqlite"/>
+        <env name="DB_DATABASE" value=":memory:"/>
+        <env name="MAIL_MAILER" value="array"/>
+        <env name="PULSE_ENABLED" value="false"/>
+        <env name="QUEUE_CONNECTION" value="sync"/>
+        <env name="SESSION_DRIVER" value="array"/>
+        <env name="TELESCOPE_ENABLED" value="false"/>
+    </php>
+</phpunit>

--- a/tests/ArchTest.php
+++ b/tests/ArchTest.php
@@ -1,0 +1,9 @@
+<?php
+
+arch()->preset()->php();
+
+arch()->preset()->security();
+
+arch()
+    ->expect(['dd', 'dump', 'ray', 'die', 'var_dump', 'ds', 'print_f'])
+    ->not->toBeUsed();

--- a/tests/Feature/Commands/DisposableEmailStatsTest.php
+++ b/tests/Feature/Commands/DisposableEmailStatsTest.php
@@ -1,0 +1,14 @@
+<?php
+
+it('displays stats via artisan command')
+    ->artisan('disposable:stats')
+    ->expectsOutputToContain('Built-in domains')
+    ->expectsOutputToContain('Custom blacklist domains')
+    ->expectsOutputToContain('Total domains')
+    ->expectsOutputToContain('Whitelist domains')
+    ->expectsOutputToContain('Remote sources')
+    ->expectsOutputToContain('Cache enabled')
+    ->expectsOutputToContain('Cache TTL')
+    ->expectsOutputToContain('Block subdomains')
+    ->expectsOutputToContain('Last synced')
+    ->assertExitCode(0);

--- a/tests/Feature/Commands/InstallDisposableEmailTest.php
+++ b/tests/Feature/Commands/InstallDisposableEmailTest.php
@@ -1,0 +1,7 @@
+<?php
+
+it('can install the package via artisan command')
+    ->artisan('erag:install-disposable-email')
+    ->expectsOutputToContain('Publishing [erag:publish-disposable-config] assets.')
+    ->expectsOutputToContain('✅ Disposable Email Package Installed Successfully!')
+    ->assertExitCode(0);

--- a/tests/Feature/Commands/UpdateDisposableEmailListTest.php
+++ b/tests/Feature/Commands/UpdateDisposableEmailListTest.php
@@ -1,0 +1,6 @@
+<?php
+
+it('updates emails database via artisan command')
+    ->artisan('erag:sync-disposable-email-list')
+    ->expectsOutputToContain('Sync complete. Synced: 1. Failed: 0.')
+    ->assertExitCode(0);

--- a/tests/Feature/Rules/DisposableEmailRuleTest.php
+++ b/tests/Feature/Rules/DisposableEmailRuleTest.php
@@ -1,0 +1,54 @@
+<?php
+
+test('validation passes with valid e-mail addresses')
+    ->expect(fn ($email) => DisposableEmailRule($email))
+    ->passes()
+    ->toBeTrue()
+    ->with(fn () => valid_emails());
+
+test('validation fails with default blacklisted domains')
+    ->expect(fn ($email) => DisposableEmailRule($email))
+    ->passes()
+    ->toBeFalse()
+    ->with(fn () => default_blacklisted_emails());
+
+test('validation fails with custom main blacklist domains')
+    ->expect(fn ($email) => DisposableEmailRule($email))
+    ->passes()
+    ->toBeFalse()
+    ->with(fn () => custom_blacklisted_emails());
+
+test('validation fails with malformed email')
+    ->expect(fn ($email) => DisposableEmailRule($email))
+    ->passes()
+    ->toBeFalse()
+    ->with(fn () => [malformed_email()]);
+
+test('validation fails with whitelisted domains')
+    ->expect(fn ($email) => DisposableEmailRule($email))
+    ->passes()
+    ->toBeTrue()
+    ->with(fn () => whitelisted_emails());
+
+it('can block subdomains according to configuration', function () {
+    $email = get_random_fixture_email_address('blacklist/blacklist_subdomain.txt');
+    $emailWithSubdomain = str_replace('@', '@mail.', $email);
+
+    // Set Blocking subdomains ON
+    config()->set('disposable-email.block_subdomains', true);
+
+    // Main domains should be flagged as disposable
+    expect(DisposableEmailRule($email))->passes()->toBeFalse();
+
+    // Sub-domain should be flagged as disposable
+    expect(DisposableEmailRule($emailWithSubdomain))->passes()->toBeFalse();
+
+    // Set Blocking subdomains OFF
+    config()->set('disposable-email.block_subdomains', false);
+
+    // Main domains should be flagged as disposable
+    expect(DisposableEmailRule($email))->passes()->toBeFalse();
+
+    // Sub-domain is accepted as valid email
+    expect(DisposableEmailRule($emailWithSubdomain))->passes()->toBeTrue();
+});

--- a/tests/Feature/Rules/ValidatorTest.php
+++ b/tests/Feature/Rules/ValidatorTest.php
@@ -1,0 +1,13 @@
+<?php
+
+test('validator rule "disposable_email"', function (string $email, bool $shouldFail) {
+    expect(validator(['email' => $email], ['email' => ['disposable_email']]))
+        ->fails()
+        ->toBe($shouldFail);
+})->with([
+    'whitelisted email' => [whitelisted_email(), false],
+    'valid email' => [valid_email(), false],
+    'default blacklisted email' => [default_blacklisted_email(), true],
+    'custom blacklisted email' => [custom_blacklisted_email(), true],
+    'malformed email' => [malformed_email(), true],
+]);

--- a/tests/Feature/Rules/WhitelistTest.php
+++ b/tests/Feature/Rules/WhitelistTest.php
@@ -1,0 +1,21 @@
+<?php
+
+test('whitelist has precedence over blacklist ', function () {
+    $emailBlacklistedDomain = custom_blacklisted_email();
+
+    // Adding an email from blacklisted domain to the whitelist
+    config()->set('disposable-email.whitelist', [$emailBlacklistedDomain]);
+
+    // Validator should NOT flag it as disposable email
+    expect(validator(['email' => $emailBlacklistedDomain], ['email' => ['disposable_email']]))
+        ->fails()
+        ->toBeFalse();
+
+    // Empty the whitelist set
+    config()->set('disposable-email.whitelist', []);
+
+    // Validator should flag this email as disposable
+    expect(validator(['email' => $emailBlacklistedDomain], ['email' => ['disposable_email']]))
+        ->fails()
+        ->toBetrue();
+});

--- a/tests/Feature/ServiceProvider/BladeDirectiveTest.php
+++ b/tests/Feature/ServiceProvider/BladeDirectiveTest.php
@@ -1,0 +1,16 @@
+<?php
+
+use Illuminate\Support\Facades\Blade;
+
+todo('Blade: "@disposableEmail" does not flag a malformed email. Verify.');
+
+test('Blade: "@disposableEmail" can validate emails', function (string $email, string $result) {
+    expect(Blade::render("@disposableEmail('{$email}') <fail> @else <pass> @enddisposableEmail"))
+        ->toContain("<{$result}>");
+})->with([
+    'default blacklisted email' => [default_blacklisted_email(), 'fail'],
+    'custom main blacklist email' => [custom_blacklisted_email(), 'fail'],
+    'whitelisted email' => [whitelisted_email(), 'pass'],
+    'valid email' => [valid_email(), 'pass'],
+    // 'malformed email' => [malformed_email(), 'fail'], //@todo
+]);

--- a/tests/Feature/ServiceProvider/DisposableFacadeTest.php
+++ b/tests/Feature/ServiceProvider/DisposableFacadeTest.php
@@ -1,0 +1,22 @@
+<?php
+
+use EragLaravelDisposableEmail\Facades\Disposable;
+
+test('Disposable Facade - Email Check')
+    ->expect(fn () => Disposable::email(default_blacklisted_email()))->toBeTrue()
+    ->expect(fn () => Disposable::email(custom_blacklisted_email()))->toBeTrue()
+    ->expect(fn () => Disposable::email(whitelisted_email()))->toBeFalse()
+    ->expect(fn () => Disposable::email(valid_email()))->toBeFalse()
+    ->expect(fn () => Disposable::email(malformed_email()))->toBeFalse();
+
+test('Disposable Facade Domain Check', function (string $email, bool $result) {
+    $domain = str($email)->after('@')->toString();
+
+    expect(Disposable::domain($email))->toBe($result);
+    expect(Disposable::domain($domain))->toBe($result);
+})->with([
+    'whitelisted email' => [whitelisted_email(), false],
+    'valid email' => [valid_email(), false],
+    'default blacklisted email' => [default_blacklisted_email(), true],
+    'custom blacklisted email' => [custom_blacklisted_email(), true],
+]);

--- a/tests/Feature/ServiceProvider/ServiceProviderTest.php
+++ b/tests/Feature/ServiceProvider/ServiceProviderTest.php
@@ -1,0 +1,5 @@
+<?php
+
+it('registers the package service provider')
+    ->expect(fn () => app()->getLoadedProviders())
+    ->toHaveKey('EragLaravelDisposableEmail\LaravelDisposableEmailServiceProvider');

--- a/tests/Feature/Support/EmailTest.php
+++ b/tests/Feature/Support/EmailTest.php
@@ -1,0 +1,8 @@
+<?php
+
+use EragLaravelDisposableEmail\Support\Email;
+
+test('All built-in domains entries are valid domains')
+    ->expect(Email::domains())
+    ->each()
+    ->toBeValidDomain();

--- a/tests/Fixtures/blacklist/another_blacklist.txt
+++ b/tests/Fixtures/blacklist/another_blacklist.txt
@@ -1,0 +1,1 @@
+second-blacklist.com

--- a/tests/Fixtures/blacklist/blacklist_subdomain.txt
+++ b/tests/Fixtures/blacklist/blacklist_subdomain.txt
@@ -1,0 +1,1 @@
+forsubdomaintest.com

--- a/tests/Fixtures/blacklist/main_blacklist.txt
+++ b/tests/Fixtures/blacklist/main_blacklist.txt
@@ -1,0 +1,7 @@
+00foobar.com
+foobaremail.com
+foo.bar.com
+0-1-2-4-4.com
+invaliddomain.local
+invaliddomain.test
+foobar.qq

--- a/tests/Fixtures/github_disposable_email.txt
+++ b/tests/Fixtures/github_disposable_email.txt
@@ -1,0 +1,4 @@
+defaultblockeddomain.com
+someother1234blocked.xyz
+baddomain.com
+l4r4v3l.xyz

--- a/tests/Fixtures/whitelist/another_whitelist.txt
+++ b/tests/Fixtures/whitelist/another_whitelist.txt
@@ -1,0 +1,1 @@
+another-trusted-domain.com

--- a/tests/Fixtures/whitelist/main_whitelist.txt
+++ b/tests/Fixtures/whitelist/main_whitelist.txt
@@ -1,0 +1,3 @@
+trusted-domain.com
+laravel.com
+pestphp.com

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,270 @@
+<?php
+
+use EragLaravelDisposableEmail\Rules\DisposableEmailRule;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Validator;
+use Illuminate\Validation\Validator as IlluminateValidator;
+use Tests\TestCase;
+
+use function Pest\Laravel\artisan;
+
+/*
+|--------------------------------------------------------------------------
+| Test Case
+|--------------------------------------------------------------------------
+|
+*/
+
+pest()
+    ->extend(TestCase::class)
+    ->use(RefreshDatabase::class)
+    ->in('Feature')
+    ->beforeEach(function () {
+        /*
+        |--------------------------------------------------------------------------
+        | Configure app with testing settings
+        |--------------------------------------------------------------------------
+        */
+
+        config()->set('disposable-email.remote_url', ['http://github.local/disposable_email.txt']);
+
+        config()->set('disposable-email.blacklist_file', fixture('blacklist'));
+
+        config()->set(
+            'disposable-email.whitelist',
+            array_merge(
+                explode(PHP_EOL, fixture_load('whitelist/main_whitelist.txt')),
+                explode(PHP_EOL, fixture_load('whitelist/another_whitelist.txt'))
+            ),
+        );
+
+        /*
+        |--------------------------------------------------------------------------
+        | HTTP Fake request
+        |--------------------------------------------------------------------------
+        */
+
+        Http::fake([
+            '://github.local*' => Http::response(fixture_load('github_disposable_email.txt'), 200),
+        ]);
+
+        /*
+        |--------------------------------------------------------------------------
+        | Updating domain list
+        |--------------------------------------------------------------------------
+        | Update the e-mail list before each test to elimate
+        | any possible interdependencies.
+        | The update command must be called after the `Http::fake`.
+        |--------------------------------------------------------------------------
+        */
+        artisan('erag:sync-disposable-email-list');
+
+    })->afterEach(
+        function () {
+            // Clean up default list file
+            $disposableListPath = fixture('blacklist/disposable_email.txt');
+
+            if (file_exists($disposableListPath)) {
+                unlink($disposableListPath);
+            }
+
+            // Ensure the list was fetched from the Http fake data.
+            Http::assertSent(fn ($request) => $request->url() === 'http://github.local/disposable_email.txt');
+        }
+    );
+
+/*
+|--------------------------------------------------------------------------
+| Expectations
+|--------------------------------------------------------------------------
+|
+*/
+
+/**
+ * @see tests/Unit/CustomExpectationsTest.php
+ */
+expect()->extend('toBeValidDomain', function () {
+    return $this->toMatch('/^(?!\-)(?:[a-zA-Z0-9\-]{0,62}[a-zA-Z0-9]\.)+[a-zA-Z]{2,63}$/');
+});
+
+/*
+|--------------------------------------------------------------------------
+| Functions
+|--------------------------------------------------------------------------
+|
+*/
+
+if (! function_exists('fixture')) {
+    /**
+     * Returns fixture file or directory path
+     *
+     * @throws RuntimeException if the file or directory does not exist.
+     */
+    function fixture(string $fixture): string
+    {
+        $path = __DIR__.str_replace('/', DIRECTORY_SEPARATOR, "/Fixtures/{$fixture}");
+
+        if (! file_exists($path)) {
+            throw new RuntimeException("Directory or file missing {$path}]");
+        }
+
+        return $path;
+    }
+}
+
+if (! function_exists('fixture_load')) {
+    /**
+     * Returns fixture file content
+     *
+     * @throws RuntimeException if the file or directory does not exist.
+     */
+    function fixture_load(string $fixture): string
+    {
+        return file_get_contents(fixture($fixture));
+    }
+}
+
+/*
+|--------------------------------------------------------------------------
+| Helpers
+|--------------------------------------------------------------------------
+|
+*/
+
+if (! function_exists('custom_blacklisted_emails')) {
+    /**
+     * Generates email addresses based on custom blacklists
+     */
+    function custom_blacklisted_emails(): array
+    {
+        return array_map(
+            fn (string $domain) => fake()->username()."@{$domain}",
+            explode(PHP_EOL, fixture_load('blacklist/main_blacklist.txt'))
+        );
+    }
+}
+
+if (! function_exists('default_blacklisted_emails')) {
+    /**
+     * Generates email addresses based on package default domains
+     */
+    function default_blacklisted_emails(): array
+    {
+        return array_map(
+            fn (string $domain) => fake()->username()."@{$domain}",
+            explode(PHP_EOL, fixture_load('github_disposable_email.txt'))
+        );
+    }
+}
+
+if (! function_exists('whitelisted_emails')) {
+    /**
+     * Generates email addresses based on package default domains
+     */
+    function whitelisted_emails(): array
+    {
+        return array_map(
+            fn (string $domain) => fake()->username()."@{$domain}",
+            explode(PHP_EOL, fixture_load('whitelist/main_whitelist.txt'))
+        );
+    }
+}
+
+if (! function_exists('get_random_fixture_domain')) {
+    /**
+     * Returns a valid email addresses using faker
+     */
+    function get_random_fixture_domain(string $fixture): string
+    {
+        $emails = explode(PHP_EOL, fixture_load($fixture));
+
+        return $emails[array_rand($emails)];
+    }
+}
+
+if (! function_exists('get_random_fixture_email_address')) {
+    /**
+     * Generates an email address from a random fixture domain
+     */
+    function get_random_fixture_email_address(string $fixture): string
+    {
+        return fake()->username().'@'.get_random_fixture_domain($fixture);
+    }
+}
+
+if (! function_exists('whitelisted_email')) {
+    /**
+     * Returns a random email address with a random whitelist domain.
+     */
+    function whitelisted_email(): string
+    {
+        return get_random_fixture_email_address('whitelist/main_whitelist.txt');
+    }
+}
+
+if (! function_exists('custom_blacklisted_email')) {
+    /**
+     * Returns a random email address with a
+     * random domain from the custom blacklist.
+     */
+    function custom_blacklisted_email(): string
+    {
+        return get_random_fixture_email_address('blacklist/main_blacklist.txt');
+    }
+}
+
+if (! function_exists('default_blacklisted_email')) {
+    /**
+     * Returns a random email address with a
+     * random domain from package default blacklist.
+     */
+    function default_blacklisted_email(): string
+    {
+        return get_random_fixture_email_address('github_disposable_email.txt');
+    }
+}
+
+if (! function_exists('valid_emails')) {
+    /**
+     * Generates many valid email addresses with faker()
+     */
+    function valid_emails(int $count = 10): array
+    {
+        return array_map(fn () => fake()->email(), range(1, $count));
+    }
+}
+
+if (! function_exists('valid_email')) {
+    /**
+     * Generates a valid email addresses with faker()
+     */
+    function valid_email(): string
+    {
+        return fake()->email();
+    }
+}
+
+if (! function_exists('malformed_email')) {
+    /**
+     * Returns a malformed email address
+     */
+    function malformed_email(): string
+    {
+        return 'malformed email';
+    }
+}
+
+if (! function_exists('DisposableEmailRule')) {
+
+    /**
+     * Laravel Validator with DisposableEmailRule for email field
+     */
+    function DisposableEmailRule(string $emailAddress): IlluminateValidator
+    {
+        return Validator::make(
+            ['email' => $emailAddress],
+            ['email' => new DisposableEmailRule]
+        );
+    }
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace Tests;
+
+use EragLaravelDisposableEmail\LaravelDisposableEmailServiceProvider;
+use Orchestra\Testbench\TestCase as OrchestraTestCase;
+
+abstract class TestCase extends OrchestraTestCase
+{
+    protected function getPackageProviders($app)
+    {
+        return [
+            LaravelDisposableEmailServiceProvider::class,
+        ];
+    }
+}

--- a/tests/Unit/CustomExpectationsTest.php
+++ b/tests/Unit/CustomExpectationsTest.php
@@ -1,0 +1,11 @@
+<?php
+
+test('toBeValidDomain - detects valid domains')
+    ->expect(['foo.com', 'foo.bar.com', '123-foobar.com', 'xn--i-7iq.ws'])
+    ->each()
+    ->toBeValidDomain();
+
+test('toBeValidDomain - detects invalid domains')
+    ->expect(['', 'foobar', 'example.com ', "'example.com'", "example.com'", '-example.com', 'http://example.com'])
+    ->each()
+    ->not->toBeValidDomain();


### PR DESCRIPTION
Hi @eramitgupta,

I've used this package a couple of times, and when I noticed there were no tests, I was motivated to contribute.

This PR adds a test suite to the code. There are no major changes such as feature additions, relevant fixes, or changes to the codebase.


Below I will summarize the most important changes.

# Pull Request

## Important points

### ❗ Pint Dependency

Pint was included as a `dependency` instead of a `dev dependency`. I couldn't find any reason for that, so I have changed that in `composer.json.`.

### Composer Scripts

I've included composer scripts to standardize the way tests are run. 

- `composer:lint` runs Laravel Pint in parallel mode to lint the code.
- `composer test:lint` tests lint with Pint in parallel mode. 
- `composer test:unit`: runs Pest, ordering the tests by *[random order](https://docs.phpunit.de/en/12.5/textui.html#test-execution-order)*. This allows identifying and fixing interdependent tests.

I have pointed the `composer test` command to run lint + unit tests.

## Architecture Testing
The test suite now counts with a simple [Arc Test](https://pestphp.com/docs/arch-testing) with the [`php`](https://pestphp.com/docs/arch-testing#preset-php) and [`security`](https://pestphp.com/docs/arch-testing#content-security) presets.

### Continuous Integration

I have added a GitHub action testing the package for Livewire 11, 12, and 13 and with PHP 8.1 - 8.5.
The workflow will run on push and pull_request.

---

## Notes

### Malformed Email

The Blade `@disposableEmail` does not flag a malformed email. 

```php
@disposableEmail('this is not an email') 
this is a disposable email
@else
this is not a disposable email
@enddisposableEmail

// Outputs: this is not a disposable email
```

While the Facade will return `false` to the malformed email.

```php
Disposable::email('this is not an email'); //false
```

And finally, `validator()` will result:

```php
validator(
    ['email' => 'this is not an email'],
    ['email' => ['disposable_email']]
)->validate();

// Outputs:   The email belongs to an unauthorized email provider.
```

At first I was a little confused because the validator message made me think this is a valid e-mail, and it is on the bad domains list. Thus the "red light".

So, it seems to me that checking if a string is a valid email address is out of the package scope. This may be the reason that the documentation also advises using the `email` validation rule.

Nevertheless, I left a `todo` in the `BladeDirectiveTest` to serve as recomendation.

Thanks and greetings,

Dan